### PR TITLE
Pragma directive

### DIFF
--- a/include/rosbridge_client_cpp/connection.h
+++ b/include/rosbridge_client_cpp/connection.h
@@ -14,8 +14,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef ROSBRIDGE_CLIENT_CPP_CONNECTION_H
-#define ROSBRIDGE_CLIENT_CPP_CONNECTION_H
+#pragma once
 
 #include "utils.h"
 
@@ -183,5 +182,3 @@ private:
 };
 
 } // namespace rosbridge_client_cpp
-
-#endif // ROSBRIDGE_CLIENT_CPP_OP_H

--- a/include/rosbridge_client_cpp/op.h
+++ b/include/rosbridge_client_cpp/op.h
@@ -14,8 +14,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef ROSBRIDGE_CLIENT_CPP_OP_H
-#define ROSBRIDGE_CLIENT_CPP_OP_H
+#pragma once
 
 #include <set>
 #include <string>
@@ -56,7 +55,7 @@ bool isTopicOP(rosbridge_client_cpp::OP op);
  */
 bool isServiceOP(rosbridge_client_cpp::OP op);
 
-}
+} // namespace rosbridge_client_cpp
 
 namespace std
 {
@@ -64,6 +63,4 @@ namespace std
  * Extension to the std namespace to provide a `to_string` method for the `rosbridge_client_cpp::OP`
  */
 std::string to_string(rosbridge_client_cpp::OP op);
-}
-
-#endif // ROSBRIDGE_CLIENT_CPP_OP_H
+} // namespace std

--- a/include/rosbridge_client_cpp/op.h
+++ b/include/rosbridge_client_cpp/op.h
@@ -62,5 +62,5 @@ namespace std
 /**
  * Extension to the std namespace to provide a `to_string` method for the `rosbridge_client_cpp::OP`
  */
-std::string to_string(rosbridge_client_cpp::OP op);
+string to_string(rosbridge_client_cpp::OP op);
 } // namespace std

--- a/include/rosbridge_client_cpp/publisher.h
+++ b/include/rosbridge_client_cpp/publisher.h
@@ -14,8 +14,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef ROSBRIDGE_CLIENT_CPP_PUBLISHER_H
-#define ROSBRIDGE_CLIENT_CPP_PUBLISHER_H
+#pragma once
 
 #include <memory>
 #include <queue>
@@ -68,5 +67,3 @@ private:
 };
 
 } // namespace rosbridge_client_cpp
-
-#endif // ROSBRIDGE_CLIENT_CPP_PUBLISHER_H

--- a/include/rosbridge_client_cpp/queues.h
+++ b/include/rosbridge_client_cpp/queues.h
@@ -14,8 +14,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef ROSBRIDGE_CLIENT_CPP_QUEUES_H
-#define ROSBRIDGE_CLIENT_CPP_QUEUES_H
+#pragma once
 
 #include <atomic>
 #include <list>
@@ -125,5 +124,3 @@ private:
 };
 
 } // namespace rosbridge_client_cpp
-
-#endif // ROSBRIDGE_CLIENT_CPP_QUEUES_H

--- a/include/rosbridge_client_cpp/rosbridge.h
+++ b/include/rosbridge_client_cpp/rosbridge.h
@@ -14,12 +14,9 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef ROSBRIDGE_CLIENT_CPP_ROSBRIDGE_H
-#define ROSBRIDGE_CLIENT_CPP_ROSBRIDGE_H
+#pragma once
 
 #include "publisher.h"
 #include "subscriber.h"
 #include "serviceserver.h"
 #include "serviceclient.h"
-
-#endif // ROSBRIDGE_CLIENT_CPP_ROSBRIDGE_H

--- a/include/rosbridge_client_cpp/rosbridgeclient.h
+++ b/include/rosbridge_client_cpp/rosbridgeclient.h
@@ -14,8 +14,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef ROSBRIDGE_CLIENT_CPP_ROSBRIDGECLIENT_H
-#define ROSBRIDGE_CLIENT_CPP_ROSBRIDGECLIENT_H
+#pragma once
 
 #include <atomic>
 #include <future>
@@ -76,6 +75,4 @@ private:
     void listen(const std::string& data);
 };
 
-} // rosbridge_client_cpp
-
-#endif // ROSBRIDGE_CLIENT_CPP_ROSBRIDGECLIENT_H
+} // namespace rosbridge_client_cpp

--- a/include/rosbridge_client_cpp/serializer.h
+++ b/include/rosbridge_client_cpp/serializer.h
@@ -14,8 +14,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef ROSBRIDGE_CLIENT_CPP_SERIALIZER_H
-#define ROSBRIDGE_CLIENT_CPP_SERIALIZER_H
+#pragma once
 
 #include <map>
 #include <random>
@@ -138,6 +137,4 @@ struct SerializerServiceResponse: public Serializer
     }
 };
 
-}
-
-#endif // ROSBRIDGE_CLIENT_CPP_ROSBRIDGE_H
+} // namespace rosbridge_client_cpp

--- a/include/rosbridge_client_cpp/serviceclient.h
+++ b/include/rosbridge_client_cpp/serviceclient.h
@@ -14,8 +14,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef ROSBRIDGE_CLIENT_CPP_SERVICECLIENT_H
-#define ROSBRIDGE_CLIENT_CPP_SERVICECLIENT_H
+#pragma once
 
 #include "queues.h"
 #include "rosbridgeclient.h"
@@ -65,6 +64,4 @@ private:
     ListenerQueue::shared_ptr listener_queue;
 };
 
-}
-
-#endif // ROSBRIDGE_CLIENT_CPP_SERVICECLIENT_H
+} // namespace rosbridge_client_cpp

--- a/include/rosbridge_client_cpp/serviceserver.h
+++ b/include/rosbridge_client_cpp/serviceserver.h
@@ -14,8 +14,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef ROSBRIDGE_CLIENT_CPP_SERVICESERVER_H
-#define ROSBRIDGE_CLIENT_CPP_SERVICESERVER_H
+#pragma once
 
 #include "queues.h"
 #include "rosbridgeclient.h"
@@ -64,6 +63,4 @@ private:
     void listener();
 };
 
-}
-
-#endif // ROSBRIDGE_CLIENT_CPP_SERVICESERVER_H
+} // namespace rosbridge_client_cpp

--- a/include/rosbridge_client_cpp/subscriber.h
+++ b/include/rosbridge_client_cpp/subscriber.h
@@ -14,8 +14,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef ROSBRIDGE_CLIENT_CPP_SUBSCRIBER_H
-#define ROSBRIDGE_CLIENT_CPP_SUBSCRIBER_H
+#pragma once
 
 #include <atomic>
 #include "rosbridgeclient.h"
@@ -57,5 +56,3 @@ private:
 };
 
 } // namespace rosbridge_client_cpp
-
-#endif // ROSBRIDGE_CLIENT_CPP_SUBSCRIBER_H

--- a/include/rosbridge_client_cpp/unserializer.h
+++ b/include/rosbridge_client_cpp/unserializer.h
@@ -14,8 +14,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef ROSBRIDGE_CLIENT_CPP_UNSERIALIZER_H
-#define ROSBRIDGE_CLIENT_CPP_UNSERIALIZER_H
+#pragma once
 
 #include <map>
 #include <random>
@@ -102,7 +101,4 @@ private:
     picojson::object json;
 };
 
-}
-
-
-#endif // ROSBRIDGE_CLIENT_CPP_UNSERIALIZER_H
+} // namespace rosbridge_client_cpp

--- a/include/rosbridge_client_cpp/utils.h
+++ b/include/rosbridge_client_cpp/utils.h
@@ -148,7 +148,7 @@ inline std::string to_string(picojson::object json)
 
 namespace std
 {
-inline std::string to_string(picojson::object j)
+inline string to_string(picojson::object j)
 {
     return rosbridge_client_cpp::to_string(j);
 }

--- a/include/rosbridge_client_cpp/utils.h
+++ b/include/rosbridge_client_cpp/utils.h
@@ -27,6 +27,7 @@
 #include <thread>
 #include <tuple>
 #include <vector>
+#include<random>
 
 #include <curl/curl.h>
 

--- a/include/rosbridge_client_cpp/utils.h
+++ b/include/rosbridge_client_cpp/utils.h
@@ -14,8 +14,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef ROSBRIDGE_CLIENT_CPP_UTILS_H
-#define ROSBRIDGE_CLIENT_CPP_UTILS_H
+#pragma once
 
 #include <atomic>
 #include <chrono>
@@ -154,5 +153,3 @@ inline std::string to_string(picojson::object j)
     return rosbridge_client_cpp::to_string(j);
 }
 } // namespace std
-
-#endif // ROSBRIDGE_CLIENT_CPP_UTILS_H


### PR DESCRIPTION
I replaced the include guards with `pragma once`  preprocessor directive. It makes it look nicer and also avoids possible name clashes in the future. Also added some end-of-namespace scope comments.
In `utils.h` I had to `include<random>` in order to compile the package. I added it as a separate commit.
Also removed some unnecessary `std::`'s within the std namespace in the last commit.